### PR TITLE
Adding Supervisord Header Config

### DIFF
--- a/8.0-swoole-nginx-prod/supervisor.conf
+++ b/8.0-swoole-nginx-prod/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.0-swoole-nginx-prod/supervisor.conf
+++ b/8.0-swoole-nginx-prod/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.0-swoole-nginx/supervisor.conf
+++ b/8.0-swoole-nginx/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.0-swoole-nginx/supervisor.conf
+++ b/8.0-swoole-nginx/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.1-swoole-nginx-prod/supervisor.conf
+++ b/8.1-swoole-nginx-prod/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.1-swoole-nginx-prod/supervisor.conf
+++ b/8.1-swoole-nginx-prod/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.1-swoole-nginx/supervisor.conf
+++ b/8.1-swoole-nginx/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.1-swoole-nginx/supervisor.conf
+++ b/8.1-swoole-nginx/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.2-swoole-nginx-prod/supervisor.conf
+++ b/8.2-swoole-nginx-prod/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.2-swoole-nginx-prod/supervisor.conf
+++ b/8.2-swoole-nginx-prod/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.2-swoole-nginx/supervisor.conf
+++ b/8.2-swoole-nginx/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.2-swoole-nginx/supervisor.conf
+++ b/8.2-swoole-nginx/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.3-swoole-nginx-prod/supervisor.conf
+++ b/8.3-swoole-nginx-prod/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.3-swoole-nginx-prod/supervisor.conf
+++ b/8.3-swoole-nginx-prod/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.3-swoole-nginx/supervisor.conf
+++ b/8.3-swoole-nginx/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.3-swoole-nginx/supervisor.conf
+++ b/8.3-swoole-nginx/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.4-swoole-nginx-prod/supervisor.conf
+++ b/8.4-swoole-nginx-prod/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.4-swoole-nginx-prod/supervisor.conf
+++ b/8.4-swoole-nginx-prod/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/8.4-swoole-nginx/supervisor.conf
+++ b/8.4-swoole-nginx/supervisor.conf
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/8.4-swoole-nginx/supervisor.conf
+++ b/8.4-swoole-nginx/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]

--- a/template/supervisor-conf.blade.php
+++ b/template/supervisor-conf.blade.php
@@ -1,3 +1,7 @@
+[supervisord]
+logfile=/dev/stdout
+nodaemon=true
+
 [program:nginx]
 depends_on = octane
 command = nginx -g "daemon off;"

--- a/template/supervisor-conf.blade.php
+++ b/template/supervisor-conf.blade.php
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
 nodaemon=true
 
 [program:nginx]


### PR DESCRIPTION
This pull request introduces updates to the `supervisor.conf` files across multiple versions of the Swoole-Nginx configurations and their templates. The changes ensure that `supervisord` logs to standard output and runs without daemonizing, improving logging consistency and container compatibility.

### Changes to `supervisor.conf` files:

* Added `[supervisord]` section with `logfile=/dev/stdout` and `nodaemon=true` to ensure logs are written to standard output and the process does not daemonize. This change has been applied to the following files:
  - `8.0-swoole-nginx-prod/supervisor.conf`
  - `8.0-swoole-nginx/supervisor.conf`
  - `8.1-swoole-nginx-prod/supervisor.conf`
  - `8.1-swoole-nginx/supervisor.conf`
  - `8.2-swoole-nginx-prod/supervisor.conf`
  - `8.2-swoole-nginx/supervisor.conf`
  - `8.3-swoole-nginx-prod/supervisor.conf`
  - `8.3-swoole-nginx/supervisor.conf`
  - `8.4-swoole-nginx-prod/supervisor.conf`
  - `8.4-swoole-nginx/supervisor.conf`

### Changes to the configuration template:

* Updated `template/supervisor-conf.blade.php` to include the `[supervisord]` section with the same logging and daemonization settings, ensuring consistency across dynamically generated configurations.